### PR TITLE
Fix blurry UI on Windows HiDPI displays

### DIFF
--- a/src/merge_app.py
+++ b/src/merge_app.py
@@ -7,6 +7,7 @@ from tkinter import filedialog, messagebox, ttk
 import logging
 from datetime import datetime
 from version import VERSION
+from windows_dpi import create_root_window
 
 # ================= LOGGER =================
 
@@ -235,7 +236,7 @@ def main():
     if len(initial_files) == 2:
         logging.info("Auto mode detected (context menu)")
 
-    root = tk.Tk()
+    root = create_root_window()
 
     def safe_exit(event=None):
         logging.info("Application closed by user")

--- a/src/split_app.py
+++ b/src/split_app.py
@@ -6,6 +6,7 @@ from tkinter import filedialog, messagebox, ttk
 import logging
 from datetime import datetime
 from version import VERSION
+from windows_dpi import create_root_window
 
 
 # ================= LOGGER =================
@@ -216,7 +217,7 @@ def main():
             initial_file = arg
             break
 
-    root = tk.Tk()
+    root = create_root_window()
 
     def safe_exit(event=None):
         logging.info("Application closed by user")

--- a/src/windows_dpi.py
+++ b/src/windows_dpi.py
@@ -1,0 +1,50 @@
+import ctypes
+import sys
+import tkinter as tk
+
+
+PER_MONITOR_AWARE_V2 = -4
+PROCESS_PER_MONITOR_DPI_AWARE = 2
+S_OK = 0
+E_ACCESSDENIED = 0x80070005
+SIGNED_E_ACCESSDENIED = -2147024891
+
+
+def configure_windows_dpi_awareness(platform=sys.platform, ctypes_module=ctypes):
+    if platform != "win32":
+        return False
+
+    windll = getattr(ctypes_module, "windll", None)
+    if windll is None:
+        return False
+
+    user32 = getattr(windll, "user32", None)
+    shcore = getattr(windll, "shcore", None)
+
+    if user32 is not None:
+        set_dpi_context = getattr(user32, "SetProcessDpiAwarenessContext", None)
+        if set_dpi_context is not None:
+            if set_dpi_context(ctypes_module.c_void_p(PER_MONITOR_AWARE_V2)):
+                return True
+
+    if shcore is not None:
+        set_dpi_awareness = getattr(shcore, "SetProcessDpiAwareness", None)
+        if set_dpi_awareness is not None:
+            result = set_dpi_awareness(PROCESS_PER_MONITOR_DPI_AWARE)
+            if result in (S_OK, E_ACCESSDENIED, SIGNED_E_ACCESSDENIED):
+                return True
+
+    if user32 is not None:
+        set_dpi_aware = getattr(user32, "SetProcessDPIAware", None)
+        if set_dpi_aware is not None:
+            return bool(set_dpi_aware())
+
+    return False
+
+
+def create_root_window(tk_module=tk, platform=sys.platform, ctypes_module=ctypes):
+    configure_windows_dpi_awareness(
+        platform=platform,
+        ctypes_module=ctypes_module,
+    )
+    return tk_module.Tk()

--- a/src/windows_dpi.py
+++ b/src/windows_dpi.py
@@ -18,8 +18,15 @@ def configure_windows_dpi_awareness(platform=sys.platform, ctypes_module=ctypes)
     if windll is None:
         return False
 
-    user32 = getattr(windll, "user32", None)
-    shcore = getattr(windll, "shcore", None)
+    try:
+        user32 = getattr(windll, "user32", None)
+    except OSError:
+        user32 = None
+
+    try:
+        shcore = getattr(windll, "shcore", None)
+    except OSError:
+        shcore = None
 
     if user32 is not None:
         set_dpi_context = getattr(user32, "SetProcessDpiAwarenessContext", None)


### PR DESCRIPTION
## Summary
- make the Tk startup path DPI-aware before creating the root window
- apply the change to both the merge and split app entry points
- keep the existing UI layout and behavior unchanged

## Validation
- compared before/after screenshots for the merge window on Windows 11 with a 2K display at 125% scaling
- verified the source files compile cleanly with `python3 -m compileall src`
